### PR TITLE
bugfix: add missing Cisco-IOS-XE-ospf model

### DIFF
--- a/gen/load_models.go
+++ b/gen/load_models.go
@@ -42,6 +42,7 @@ var models = []string{
 	"https://raw.githubusercontent.com/YangModels/yang/main/vendor/cisco/xe/1771/Cisco-IOS-XE-pppoe.yang",
 	"https://raw.githubusercontent.com/YangModels/yang/main/vendor/cisco/xe/1771/Cisco-IOS-XE-bgp.yang",
 	"https://raw.githubusercontent.com/YangModels/yang/main/vendor/cisco/xe/1771/Cisco-IOS-XE-ospfv3.yang",
+	"https://raw.githubusercontent.com/YangModels/yang/main/vendor/cisco/xe/1771/Cisco-IOS-XE-ospf.yang",
 }
 
 const (


### PR DESCRIPTION
Running generator on freshly pulled repo was getting panic. Traced to missing model in load models.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x5cd507]

goroutine 1 [running]:
main.resolvePath(0xc018965080, {0xc000094854?, 0xc0000b0600?})
        /home/justinr/netascode/terraform-provider-iosxe/gen/generator.go:258 +0x1a7
main.augmentConfig(0xc0001566e8, {0xc0000b0600, 0x1f, 0x20})
        /home/justinr/netascode/terraform-provider-iosxe/gen/generator.go:366 +0xeb
main.main()
        /home/justinr/netascode/terraform-provider-iosxe/gen/generator.go:471 +0x333
exit status 2
```
